### PR TITLE
Bugfix: Change import of OrdersHighcharts component

### DIFF
--- a/modules/Orders.test.tsx
+++ b/modules/Orders.test.tsx
@@ -3,7 +3,6 @@ import { render, screen } from '@testing-library/react'
 import fetchMock from 'jest-fetch-mock'
 import Orders from './Orders'
 import { ordersMapped } from '../mocks/ordersMapped'
-import Highcharts from 'highcharts/highstock'
 import { ORDER_SUMMARY_LABELS } from './OrdersSummary'
 
 jest.mock('highcharts/highstock')
@@ -33,14 +32,6 @@ describe('Orders', () => {
   })
 
   it('renders summary correctly', async () => {
-    const firstOrderDate = '2022-01-01'
-    const lastOrderDate = '2022-06-01'
-
-    jest
-      .spyOn(Highcharts, 'dateFormat')
-      .mockReturnValueOnce(firstOrderDate)
-      .mockReturnValueOnce(lastOrderDate)
-
     await renderComponent()
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
@@ -60,10 +51,10 @@ describe('Orders', () => {
 
     expect(
       screen.getByText(ORDER_SUMMARY_LABELS[0] + ':').parentNode
-    ).toHaveTextContent(firstOrderDate)
+    ).toHaveTextContent('2018-09-05')
     expect(
       screen.getByText(ORDER_SUMMARY_LABELS[1] + ':').parentNode
-    ).toHaveTextContent(lastOrderDate)
+    ).toHaveTextContent('2019-02-02')
     expect(
       screen.getByText(ORDER_SUMMARY_LABELS[2] + ':').parentNode
     ).toHaveTextContent(ordersMapped.ordersTotal.toString())

--- a/modules/Orders.tsx
+++ b/modules/Orders.tsx
@@ -1,7 +1,9 @@
 import React, { useEffect, useState } from 'react'
-import Highcharts from 'highcharts/highstock'
 import Head from 'next/head'
-import OrderHighcharts from './OrdersHighcharts'
+import dynamic from 'next/dynamic'
+const OrdersHighcharts = dynamic(() => import('./OrdersHighcharts'), {
+  ssr: false,
+})
 import OrdersSummary from './OrdersSummary'
 import { OrdersMapped } from '../types/OrdersMapped'
 import styles from './Orders.module.scss'
@@ -11,9 +13,6 @@ const Orders: React.FC = () => {
   const [orders, setOrders] = useState<OrdersMapped | null>(null)
   const [firstOrderDate, setFirstOrderDate] = useState('')
   const [lastOrderDate, setLastOrderDate] = useState('')
-
-  const dateFormat = '%Y/%m/%d'
-  const highchartsContainerId = 'highcharts-container'
 
   useEffect(() => {
     const fetchOrders = async (): Promise<void> => {
@@ -29,12 +28,13 @@ const Orders: React.FC = () => {
 
           const orders = data.orders
           const seriesItems = orders.seriesItems
-          const firstOrderDate = Highcharts.dateFormat(
-            dateFormat,
-            seriesItems[0].created
-          )
-          const lastOrderDate = Highcharts.dateFormat(
-            dateFormat,
+          const formatter = new Intl.DateTimeFormat('en-CA', {
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+          })
+          const firstOrderDate = formatter.format(seriesItems[0].created)
+          const lastOrderDate = formatter.format(
             seriesItems[seriesItems.length - 1].created
           )
 
@@ -62,13 +62,9 @@ const Orders: React.FC = () => {
         {loading && (
           <div className={styles.loader} data-testid="orders-loader"></div>
         )}
-        <div id={highchartsContainerId}></div>
         {orders && (
           <>
-            <OrderHighcharts
-              containerId={highchartsContainerId}
-              orders={orders}
-            />
+            <OrdersHighcharts orders={orders} />
             <OrdersSummary
               orders={orders}
               firstOrderDate={firstOrderDate}

--- a/modules/OrdersHighcharts.tsx
+++ b/modules/OrdersHighcharts.tsx
@@ -3,7 +3,7 @@ import Highcharts from 'highcharts/highstock'
 import * as ReactDOMServer from 'react-dom/server'
 import cx from 'classnames'
 import styles from './Orders.module.scss'
-import React from 'react'
+import React, { useEffect } from 'react'
 
 const tooltipHeaderAsString = (): string =>
   ReactDOMServer.renderToString(
@@ -118,14 +118,17 @@ const initHighcharts = (containerId: string, orders: OrdersMapped): void => {
 }
 
 interface Props {
-  containerId: string
   orders: OrdersMapped
 }
 
-const OrdersHighcharts: React.FC<Props> = ({ containerId, orders }) => {
-  initHighcharts(containerId, orders)
+const OrdersHighcharts: React.FC<Props> = ({ orders }) => {
+  const highchartsContainerId = 'highcharts-container'
 
-  return <></>
+  useEffect(() => {
+    initHighcharts(highchartsContainerId, orders)
+  }, [highchartsContainerId, orders])
+
+  return <div id={highchartsContainerId}></div>
 }
 
 export default OrdersHighcharts


### PR DESCRIPTION
This PR changes the import of `OrdersHighcharts` component in browser (not ssr) otherwise there could be errors on the next server side with latest [Highcharts version 12](https://www.highcharts.com/blog/news/highcharts-version-12/). It also uses [`Intl.DateTimeFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat) for formatting dates in `Orders` component instead of the Highcharts direct version.