### PR TITLE
Stop tracking generated next-env.d.ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 # next.js
 /.next/
 /out/
+next-env.d.ts
 
 # production
 .env

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import './.next/dev/types/routes.d.ts';
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -8,13 +8,13 @@
     "build": "next build",
     "start": "NODE_ENV=production ts-node server/index.ts",
     "lint": "eslint",
-    "lintAll": "prettier --check . && eslint . && stylelint **/*.scss && tsc --noEmit",
+    "lintAll": "next typegen && prettier --check . && eslint . && stylelint **/*.scss && tsc --noEmit",
     "test": "vitest",
     "testAll": "vitest run --coverage",
     "test:ui": "vitest --ui",
     "prettier": "prettier --check .",
     "stylelint": "stylelint **/*.scss",
-    "tsc": "tsc --noEmit"
+    "tsc": "next typegen && tsc --noEmit"
   },
   "dependencies": {
     "cookie": "^2.0.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,6 +31,7 @@
   },
   "include": [
     "next-env.d.ts",
+    ".next/types/**/*.ts",
     "**/*.ts",
     "**/*.tsx"
   ],


### PR DESCRIPTION
## Summary
- Add `next-env.d.ts` to `.gitignore` and remove it from version control
- Run `next typegen` before type checks in `lintAll` and `tsc` so CI and local lint still work
- Include `.next/types/**/*.ts` in `tsconfig.json` per Next.js guidance

## Why
Next.js 16 rewrites `next-env.d.ts` depending on whether `next dev` or `next build` was run last, which causes noisy unrelated diffs when the file is tracked.

## Test plan
- [x] `npm run lintAll` passes locally
- [x] CI lint/test/build workflow passes