### PR TITLE
Fix ts-node resolution for cookie v2

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -42,7 +42,7 @@
   "ts-node": {
     "compilerOptions": {
       "module": "commonjs",
-      "moduleResolution": "node10"
+      "moduleResolution": "bundler"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Switch ts-node `moduleResolution` from `node10` to `bundler` in `tsconfig.json`

## Why
After upgrading to `cookie` v2 (ESM-only, `exports`-based package), `npm run dev` failed with `Cannot find module 'cookie'`. `tsc --noEmit` worked because the main compiler config already uses `bundler` resolution; ts-node had its own override still on `node10`.

## Test plan
- [x] `npm run dev` starts successfully
- [x] `npm run lintAll` passes
- [x] CI lint/test/build workflow passes